### PR TITLE
Enable secondary joystick fire button as "jump"

### DIFF
--- a/CORE/vhdl/config.vhd
+++ b/CORE/vhdl/config.vhd
@@ -92,7 +92,8 @@ constant SCR_WELCOME : string :=
    "------------\n"                       &
    "Joy 1 or arrows to move your knight.\n"&
    "To shoot, press the fire button or left shift.\n" &
-   "To jump, press up and fire simulatenously, or space.\n" &
+   "To jump, press up and fire simulatenously,\n" &
+   "  secondary fire button, or space.\n" &
    "\n\n    Press Space to continue.\n"; 
    
 constant HELP_1 : string :=

--- a/CORE/vhdl/main.vhd
+++ b/CORE/vhdl/main.vhd
@@ -257,11 +257,11 @@ begin
             else -- standard inputs
                 p1_n_fire <= joy_1_fire_n_i and keyboard_n(m65_left_shift);
                 p1_n_up <= joy_1_up_n_i and keyboard_n(m65_up_crsr);
-                p1_n_jump <= keyboard_n(m65_space);
+                p1_n_jump <= '0' when (keyboard_n(m65_space) = '0' or pot1_x_i = x"FF") else '1';
                 
                 p2_n_fire <= joy_2_fire_n_i and keyboard_n(m65_left_shift);
                 p2_n_up <= joy_2_up_n_i and keyboard_n(m65_up_crsr);
-                p2_n_jump <= keyboard_n(m65_space);
+                p2_n_jump <= '0' when (keyboard_n(m65_space) = '0' or pot2_x_i = x"FF") else '1';
             end if;
         end if;
     end process;


### PR DESCRIPTION
This small PR enables the secondary fire button on C64-style joysticks as the "jump" button, when the "Up + Fire = Jump" configuration option is disabled.